### PR TITLE
Improve generalization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "symfony/console": "^3.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5"
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "byjg/anydataset": "3.0.*",
-    "byjg/uri": "1.0.*",
-    "symfony/console": "3.1.*"
+    "byjg/anydataset": "^3.0",
+    "byjg/uri": "^1.0",
+    "symfony/console": "^3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "byjg/uri": "1.0.*",
     "symfony/console": "3.1.*"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^6.5"
+  },
   "autoload": {
     "psr-4": {
       "ByJG\\DbMigration\\": "src/"

--- a/example/sqlite/.gitignore
+++ b/example/sqlite/.gitignore
@@ -1,0 +1,2 @@
+# Temporary SQLite file (used in tests) 
+test.sqlite

--- a/tests/SqliteDatabaseTest.php
+++ b/tests/SqliteDatabaseTest.php
@@ -4,7 +4,7 @@ require_once 'BaseDatabase.php';
 
 class SqliteDatabaseTest extends BaseDatabase
 {
-    protected $uri = 'sqlite:///tmp/teste.sqlite';
+    protected $path = __DIR__ . '/../example/sqlite/test.sqlite';
 
     /**
      * @var \ByJG\DbMigration\Migration
@@ -13,7 +13,11 @@ class SqliteDatabaseTest extends BaseDatabase
 
     public function setUp()
     {
-        $this->migrate = new \ByJG\DbMigration\Migration(new \ByJG\Util\Uri($this->uri), __DIR__ . '/../example/sqlite');
+        # Dump SQLite database.
+        file_put_contents($this->path, '');
+
+        $uri = new \ByJG\Util\Uri("sqlite://{$this->path}");
+        $this->migrate = new \ByJG\DbMigration\Migration($uri, __DIR__ . '/../example/sqlite');
         parent::setUp();
     }
 }


### PR DESCRIPTION
Hello,

I'd like to use your library but have an versions conflict. I found that you're using the wildcard version range which dramatically limits the possible versions to use. I suggest to change it either to [caret](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) or [tilde](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) version range. See that other libraries also use this notation (e.g. [symfony/console](https://github.com/symfony/console/blob/master/composer.json)).

More information in commits (note that they contains  not only titles but also descriptions).

Thanks in advance and keep up the good work!