### PR TITLE
Allow users to choose migration table

### DIFF
--- a/src/Console/ConsoleCommand.php
+++ b/src/Console/ConsoleCommand.php
@@ -44,10 +44,18 @@ abstract class ConsoleCommand extends Command
                 InputOption::VALUE_NONE,
                 'Remove the check for base.sql file'
             )
+            ->addOption(
+                'migration-table',
+                'm',
+                InputOption::VALUE_OPTIONAL,
+                'Name of the migration table',
+                'migration_version'
+            )
             ->addUsage('')
             ->addUsage('Example: ')
             ->addUsage('   migrate reset mysql://root:password@server/database')
             ->addUsage('   migrate up mysql://root:password@server/database')
+            ->addUsage('   migrate up mysql://root:password@server/database --migration-table=my_migrations')
             ->addUsage('   migrate down mysql://root:password@server/database')
             ->addUsage('   migrate up --up-to=10 --path=/somepath mysql://root:password@server/database')
             ->addUsage('   migrate down --up-to=3 --path=/somepath mysql://root:password@server/database')
@@ -89,8 +97,13 @@ abstract class ConsoleCommand extends Command
 
         $requiredBase = !$input->getOption('no-base');
 
+        $migrationTable = $input->getOption('migration-table');
+        if (!$migrationTable) {
+            $migrationTable = (!empty(getenv('MIGRATE_TABLE')) ? getenv('MIGRATE_TABLE') : "migration_version");
+        }
+        $this->path = realpath($this->path);
         $uri = new Uri($this->connection);
-        $this->migration = new Migration($uri, $this->path, $requiredBase);
+        $this->migration = new Migration($uri, $this->path, $requiredBase, $migrationTable);
         $this->migration
             ->registerDatabase('sqlite', SqliteDatabase::class)
             ->registerDatabase('mysql', MySqlDatabase::class)

--- a/src/Database/DatabaseInterface.php
+++ b/src/Database/DatabaseInterface.php
@@ -28,4 +28,6 @@ interface DatabaseInterface
     public function createVersion();
 
     public function getDbDriver();
+
+    public function getMigrationTable();
 }

--- a/src/Database/DblibDatabase.php
+++ b/src/Database/DblibDatabase.php
@@ -35,14 +35,14 @@ class DblibDatabase extends AbstractDatabase
         $this->getDbDriver()->execute("drop database $database");
     }
 
-    protected function createTableIfNotExists($database, $table, $createTable)
+    protected function createTableIfNotExists($database, $createTable)
     {
         $this->getDbDriver()->execute("use $database");
 
         $sql = "IF (NOT EXISTS (SELECT * 
                  FROM INFORMATION_SCHEMA.TABLES 
                  WHERE TABLE_SCHEMA = 'dbo' 
-                 AND  TABLE_NAME = '$table'))
+                 AND  TABLE_NAME = '" . $this->getMigrationTable() . "'))
             BEGIN
                 $createTable
             END";
@@ -57,9 +57,8 @@ class DblibDatabase extends AbstractDatabase
     public function createVersion()
     {
         $database = preg_replace('~^/~', '', $this->getDbDriver()->getUri()->getPath());
-        $table = 'migration_version';
-        $createTable = 'CREATE TABLE migration_version (version int, status varchar(20))';
-        $this->createTableIfNotExists($database, $table, $createTable);
+        $createTable = 'CREATE TABLE ' . $this->getMigrationTable() . ' (version int, status varchar(20))';
+        $this->createTableIfNotExists($database, $createTable);
         $this->checkExistsVersion();
     }
 

--- a/src/Database/MySqlDatabase.php
+++ b/src/Database/MySqlDatabase.php
@@ -40,7 +40,7 @@ class MySqlDatabase extends AbstractDatabase
      */
     public function createVersion()
     {
-        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS migration_version (version int, status varchar(20))');
+        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS ' . $this->getMigrationTable() . ' (version int, status varchar(20))');
         $this->checkExistsVersion();
     }
 

--- a/src/Database/PgsqlDatabase.php
+++ b/src/Database/PgsqlDatabase.php
@@ -62,7 +62,7 @@ class PgsqlDatabase extends AbstractDatabase
      */
     public function createVersion()
     {
-        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS migration_version (version int, status varchar(20))');
+        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS ' . $this->getMigrationTable() . ' (version int, status varchar(20))');
         $this->checkExistsVersion();
     }
 

--- a/src/Database/SqliteDatabase.php
+++ b/src/Database/SqliteDatabase.php
@@ -36,7 +36,7 @@ class SqliteDatabase extends AbstractDatabase
      */
     public function createVersion()
     {
-        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS migration_version (version int, status varchar(20))');
+        $this->getDbDriver()->execute('CREATE TABLE IF NOT EXISTS ' . $this->getMigrationTable() . ' (version int, status varchar(20))');
         $this->checkExistsVersion();
     }
 

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -40,6 +40,10 @@ class Migration
      * @var array
      */
     protected $databases = [];
+    /**
+     * @var string
+     */
+    private $migrationTable;
 
     /**
      * Migration constructor.
@@ -47,15 +51,17 @@ class Migration
      * @param UriInterface $uri
      * @param string $folder
      * @param bool $requiredBase Define if base.sql is required
-     * @throws \ByJG\DbMigration\Exception\InvalidMigrationFile
+     * @param string $migrationTable
+     * @throws InvalidMigrationFile
      */
-    public function __construct(UriInterface $uri, $folder, $requiredBase = true)
+    public function __construct(UriInterface $uri, $folder, $requiredBase = true, $migrationTable = 'migration_version')
     {
         $this->uri = $uri;
         $this->folder = $folder;
         if ($requiredBase && !file_exists($this->folder . '/base.sql')) {
             throw new InvalidMigrationFile("Migration script '{$this->folder}/base.sql' not found");
         }
+        $this->migrationTable = $migrationTable;
     }
 
     /**
@@ -86,7 +92,7 @@ class Migration
     {
         if (is_null($this->dbCommand)) {
             $class = $this->getDatabaseClassName();
-            $this->dbCommand = new $class($this->uri);
+            $this->dbCommand = new $class($this->uri, $this->migrationTable);
         }
         return $this->dbCommand;
     }

--- a/tests/BaseDatabase.php
+++ b/tests/BaseDatabase.php
@@ -9,6 +9,8 @@ abstract class BaseDatabase extends \PHPUnit\Framework\TestCase
      */
     protected $migrate = null;
 
+    protected $migrationTable = 'migration_version';
+
     public function setUp()
     {
         // create Migrate object in the parent!!!
@@ -77,9 +79,9 @@ abstract class BaseDatabase extends \PHPUnit\Framework\TestCase
 
     protected function assertVersion0()
     {
-        $version = $this->migrate->getDbDriver()->getScalar('select version from migration_version');
+        $version = $this->migrate->getDbDriver()->getScalar('select version from '. $this->migrationTable);
         $this->assertEquals(0, $version);
-        $status = $this->migrate->getDbDriver()->getScalar('select status from migration_version');
+        $status = $this->migrate->getDbDriver()->getScalar('select status from '. $this->migrationTable);
         $this->assertEquals('complete', $status);
 
         $iterator = $this->migrate->getDbDriver()->getIterator('select * from users');
@@ -109,9 +111,9 @@ abstract class BaseDatabase extends \PHPUnit\Framework\TestCase
 
     protected function assertVersion1()
     {
-        $version = $this->migrate->getDbDriver()->getScalar('select version from migration_version');
+        $version = $this->migrate->getDbDriver()->getScalar('select version from '. $this->migrationTable);
         $this->assertEquals(1, $version);
-        $status = $this->migrate->getDbDriver()->getScalar('select status from migration_version');
+        $status = $this->migrate->getDbDriver()->getScalar('select status from '. $this->migrationTable);
         $this->assertEquals('complete', $status);
 
         $iterator = $this->migrate->getDbDriver()->getIterator('select * from users');
@@ -141,9 +143,9 @@ abstract class BaseDatabase extends \PHPUnit\Framework\TestCase
 
     protected function assertVersion2()
     {
-        $version = $this->migrate->getDbDriver()->getScalar('select version from migration_version');
+        $version = $this->migrate->getDbDriver()->getScalar('select version from '. $this->migrationTable);
         $this->assertEquals(2, $version);
-        $status = $this->migrate->getDbDriver()->getScalar('select status from migration_version');
+        $status = $this->migrate->getDbDriver()->getScalar('select status from '. $this->migrationTable);
         $this->assertEquals('complete', $status);
 
         $iterator = $this->migrate->getDbDriver()->getIterator('select * from users');

--- a/tests/MysqlDatabaseTest.php
+++ b/tests/MysqlDatabaseTest.php
@@ -20,4 +20,14 @@ class MysqlDatabaseTest extends BaseDatabase
         $this->migrate->registerDatabase("mysql", \ByJG\DbMigration\Database\MySqlDatabase::class);
         parent::setUp();
     }
+
+    public function testUsingCustomTable()
+    {
+        $this->migrationTable = 'migration_table';
+
+        $this->migrate = new \ByJG\DbMigration\Migration(new \ByJG\Util\Uri($this->uri), __DIR__ . '/../example/mysql', true, $this->migrationTable);
+        $this->migrate->registerDatabase("mysql", \ByJG\DbMigration\Database\MySqlDatabase::class);
+
+        parent::testUpVersion1();
+    }
 }

--- a/tests/PostgresDatabaseTest.php
+++ b/tests/PostgresDatabaseTest.php
@@ -21,4 +21,14 @@ class PostgresDatabaseTest extends BaseDatabase
         $this->migrate->registerDatabase("pgsql", \ByJG\DbMigration\Database\PgsqlDatabase::class);
         parent::setUp();
     }
+
+    public function testUsingCustomTable()
+    {
+        $this->migrationTable = 'migration_table';
+
+        $this->migrate = new \ByJG\DbMigration\Migration(new \ByJG\Util\Uri($this->uri), __DIR__ . '/../example/postgres', true, $this->migrationTable);
+        $this->migrate->registerDatabase("pgsql", \ByJG\DbMigration\Database\PgsqlDatabase::class);
+
+        parent::testUpVersion1();
+    }
 }

--- a/tests/SqlServerDatabaseTest.php
+++ b/tests/SqlServerDatabaseTest.php
@@ -28,4 +28,14 @@ class SqlServerDatabaseTest extends BaseDatabase
         $this->migrate->registerDatabase("dblib", \ByJG\DbMigration\Database\DblibDatabase::class);
         parent::setUp();
     }
+
+    public function testUsingCustomTable()
+    {
+        $this->migrationTable = 'migration_table';
+
+        $this->migrate = new \ByJG\DbMigration\Migration(new \ByJG\Util\Uri($this->uri), __DIR__ . '/../example/sql_server', true, $this->migrationTable);
+        $this->migrate->registerDatabase("dblib", \ByJG\DbMigration\Database\DblibDatabase::class);
+
+        parent::testUpVersion1();
+    }
 }

--- a/tests/SqliteDatabaseTest.php
+++ b/tests/SqliteDatabaseTest.php
@@ -24,4 +24,18 @@ class SqliteDatabaseTest extends BaseDatabase
         $this->migrate->registerDatabase("sqlite", \ByJG\DbMigration\Database\SqliteDatabase::class);
         parent::setUp();
     }
+
+    public function testUsingCustomTable()
+    {
+        $this->migrationTable = 'migration_table';
+
+        file_put_contents($this->path, '');
+
+        $uri = new \ByJG\Util\Uri("sqlite://{$this->path}");
+        $this->migrate = new \ByJG\DbMigration\Migration($uri, __DIR__ . '/../example/sqlite', true, $this->migrationTable);
+        $this->migrate->registerDatabase("sqlite", \ByJG\DbMigration\Database\SqliteDatabase::class);
+
+        parent::testUpVersion1();
+    }
+
 }


### PR DESCRIPTION
The goal of this PR is to allow users to choose the name of the table used to store migration.