### PR TITLE
[Feature] Make trigger migration possible

### DIFF
--- a/src/Database/DblibDatabase.php
+++ b/src/Database/DblibDatabase.php
@@ -65,7 +65,7 @@ class DblibDatabase extends AbstractDatabase
 
     public function executeSql($sql)
     {
-        $statements = explode(";", $sql);
+        $statements = preg_split("/;(\r\n|\r|\n)/", $sql);
 
         foreach ($statements as $sql) {
             $this->executeSqlInternal($sql);

--- a/src/Database/PgsqlDatabase.php
+++ b/src/Database/PgsqlDatabase.php
@@ -68,7 +68,7 @@ class PgsqlDatabase extends AbstractDatabase
 
     public function executeSql($sql)
     {
-        $statements = explode(";", $sql);
+        $statements = preg_split("/;(\r\n|\r|\n)/", $sql);
 
         foreach ($statements as $sql) {
             $this->executeSqlInternal($sql);

--- a/src/Database/SqliteDatabase.php
+++ b/src/Database/SqliteDatabase.php
@@ -42,7 +42,7 @@ class SqliteDatabase extends AbstractDatabase
 
     public function executeSql($sql)
     {
-        $statements = explode(";", $sql);
+        $statements = preg_split("/;(\r\n|\r|\n)/", $sql);
 
         foreach ($statements as $sql) {
             $this->executeSqlInternal($sql);


### PR DESCRIPTION
### Use case

I was trying to include a `CREATE FUNCTION` statement in a migration file, but I kept getting an `unterminated dollar-quoted string at or near "$$` error. Upon inspection of the code I saw that the library explodes the whole content of the migration file at the semicolons, and the statement was being diced up in multiple parts.


### Solution

As a workaround I made it explode at the `";\n"` sequence, so you can select which semicolons you need to preserve with an innocuous comment.


### Example

```sql
BEGIN;

CREATE TABLE emp (
    empname text,
    salary integer,
    last_date timestamp,
    last_user text
);

CREATE FUNCTION emp_stamp() RETURNS trigger AS $emp_stamp$
    BEGIN
        -- Check that empname and salary are given
        IF NEW.empname IS NULL THEN
            RAISE EXCEPTION 'empname cannot be null'; --
        END IF; --
        IF NEW.salary IS NULL THEN
            RAISE EXCEPTION '% cannot have null salary', NEW.empname; --
        END IF; --

        -- Who works for us when they must pay for it?
        IF NEW.salary < 0 THEN
            RAISE EXCEPTION '% cannot have a negative salary', NEW.empname; --
        END IF; --

        -- Remember who changed the payroll when
        NEW.last_date := current_timestamp; --
        NEW.last_user := current_user; --
        RETURN NEW; --
    END; --
$emp_stamp$ LANGUAGE plpgsql;

CREATE TRIGGER emp_stamp BEFORE INSERT OR UPDATE ON emp
    FOR EACH ROW EXECUTE PROCEDURE emp_stamp();

COMMIT;
```

(Source: https://www.postgresql.org/docs/10/static/plpgsql-trigger.html)


PS It's ugly and hacky, but for now it works... Though it should be documented. If you accept this change I'd also like to contribute a small section on tips about writing plain SQL migrations.  I've stumbled upon a few more gotchas.